### PR TITLE
Use `bluebird` instead of `promise` to be 100% Promises/A+ compliant

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ superagent-promise
 ==================
 
 Simple/dumb promise wrapper for superagent. Both `superagent` and
-`promise` are peerDependencies.
+`bluebird` are peerDependencies.
 
 
 ## Usage

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@
 var superagent  = require('superagent');
 
 // in the browser Promise is expected to be defined.
-var Promise = this.Promise || require('promise');
+var Promise = this.Promise || require('bluebird');
 
 /**
  * Request object similar to superagent.Request, but with end() returning

--- a/index_test.js
+++ b/index_test.js
@@ -24,13 +24,6 @@ suite('superagent-promise', function() {
           'Content-Type': 'text/plain'
         });
         res.end(errorBody);
-      } else if(/error$/.test(req.url)) {
-        debug("Responding with 200, but mismatching Content-Length");
-        res.writeHead(404, {
-          'Content-Length': successBody.length - 2,
-          'Content-Type': 'text/plain'
-        });
-        res.end(successBody);
       }
     });
 
@@ -90,7 +83,10 @@ suite('superagent-promise', function() {
 
   test('test error', function(done) {
     var addr = server.address();
-    var url = 'http://' + addr.address + ':' + addr.port + "/error";
+    var url = 'http://' + addr.address + ':' + (addr.port + 1);
+
+    // superagent doesn't throw errors for 4xx/5xx status
+    // codes so we use wrong port number to trigger error
 
     request('GET', url).end().then(function(res) {
       assert.ok(false);

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "peerDependencies": {
     "superagent": ">= 0.16.0",
-    "promise": ">= 3.2.0"
+    "bluebird": ">= 2.1.2"
   },
   "devDependencies": {
     "browser-test": "0.0.0-alpha.2",
@@ -30,7 +30,7 @@
     "debug": "0.7.4",
     "mocha": "~1.17.1",
     "node-static": "^0.7.3",
-    "promise": ">= 3.2.0",
+    "bluebird": ">= 2.1.2",
     "superagent": ">= 0.16.0"
   }
 }


### PR DESCRIPTION
As `promise` isn't 100% Promises/A+ compliant, you get into situation with really annoying bugs like `method does not exist`, etc. I see no reason why we should fix another promises library when we can simply make a switch to production-ready solution. The only reason i decided to go with `bluebird` and not `q` is because i use and both projects are great anyway.