### PR TITLE
Paramaterize all the things

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,19 +8,34 @@ Simple/dumb promise wrapper for superagent. Both `superagent` and
 ## Usage
 
 ```js
-var agent = require('superagent-promise');
+var agent = require('superagent-promise')(require('superagent'), this.Promise || require('promise'));
 
-// method, url form
-agent('GET', 'http://google.com').
-  end().
-  then(function onResult(res) {
+// method, url form with `end`
+agent('GET', 'http://google.com')
+  .end()
+  .then(function onResult(res) {
+    // do stuff
+  });
+
+// method, url form with `then`
+agent('GET', 'http://google.com')
+  .then(function onResult(res) {
+    // do stuff
+  });
+
+
+// helper functions: get, head, patch, post, put, del
+agent.put('http://myxfoo', 'data')
+  .end()
+  .then(function(res) {
+    // do stuff`
   });
 
 // helper functions: get, head, patch, post, put, del
-agent().
-  put('http://myxfoo', 'data').
-  end().
-  then(function(res) {
+agent.put('http://myxfoo', 'data').
+  .then(function(res) {
+    // do stuff
   });
+
 
 ```

--- a/index_test.js
+++ b/index_test.js
@@ -1,6 +1,6 @@
 suite('superagent-promise', function() {
   var assert  = require('assert');
-  var request = require('./');
+  var request = require('./')(require('superagent'), require('es6-promise').Promise);
   var http    = require('http');
   var debug   = require('debug')('index_test');
 
@@ -11,22 +11,22 @@ suite('superagent-promise', function() {
   setup(function(done) {
     server = http.createServer(function(req, res) {
       if (/success$/.test(req.url)) {
-        debug("Responding with 200");
+        debug('Responding with 200');
         res.writeHead(200, {
           'Content-Length': successBody.length,
           'Content-Type': 'text/plain'
         });
         res.end(successBody);
       } else if(/NotFound$/.test(req.url)) {
-        debug("Responding with 404");
+        debug('Responding with 404');
         res.writeHead(404, {
           'Content-Length': errorBody.length,
           'Content-Type': 'text/plain'
         });
         res.end(errorBody);
       } else if(/error$/.test(req.url)) {
-        debug("Responding with 200, but mismatching Content-Length");
-        res.writeHead(404, {
+        debug('Responding with 200, but mismatching Content-Length');
+        res.writeHead(200, {
           'Content-Length': successBody.length - 2,
           'Content-Type': 'text/plain'
         });
@@ -34,51 +34,103 @@ suite('superagent-promise', function() {
       }
     });
 
-    server.listen(0, done);
+    server.listen(0, function() {
+      debug('listen');
+      done();
+    });
   });
 
   teardown(function(done) {
-    server.close(done);
-  });
-
-  test('issue request', function() {
-    var addr = server.address();
-    var url = 'http://' + addr.address + ':' + addr.port + "/success";
-
-    return request('GET', url).end().then(function(res) {
-      assert.equal(res.text, successBody);
-    });
-  });
-
-  test('issue request with .get', function() {
-    var addr = server.address();
-    var url = 'http://' + addr.address + ':' + addr.port + "/success";
-
-    return request.get(url).end().then(function(res) {
-      assert.equal(res.text, successBody);
-    });
-  });
-
-  test('issue 404 request', function() {
-    var addr = server.address();
-    var url = 'http://' + addr.address + ':' + addr.port + "/NotFound";
-
-    return request('GET', url).end().then(function(res) {
-      assert.ok(!res.ok);
-      assert.equal(res.text, errorBody);
-    });
-  });
-
-  test('test error', function(done) {
-    var addr = server.address();
-    var url = 'http://' + addr.address + ':' + addr.port + "/error";
-
-    request('GET', url).end().then(function(res) {
-      assert.ok(false);
-      done();
-    }, function(err) {
-      assert.ok(err);
+    server.close(function() {
+      debug('teardown');
       done();
     });
+    server = undefined;
   });
+
+  suite('#end', function() {
+    test('issue request', function(done) {
+      var addr = server.address();
+      var url = 'http://' + addr.address + ':' + addr.port + '/success';
+
+      request('GET', url).end().then(function(res) {
+        assert.equal(res.text, successBody);
+      }).then(done).catch(done);
+    });
+
+    test('issue request with .get', function(done) {
+      var addr = server.address();
+      var url = 'http://' + addr.address + ':' + addr.port + '/success';
+
+      request.get(url).end().then(function(res) {
+        assert.equal(res.text, successBody);
+      }).then(done).catch(done);
+    });
+
+    test('issue 404 request', function(done) {
+      var addr = server.address();
+      var url = 'http://' + addr.address + ':' + addr.port + '/NotFound';
+
+      request('GET', url).end().then(undefined, function(err) {
+        assert.equal(err.status, 404)
+        assert.equal(err.response.text, errorBody);
+
+      }).then(done).catch(done);
+    });
+
+    test('test error', function(done) {
+      var addr = server.address();
+      var url = 'http://' + addr.address + ':' + addr.port + '/error';
+
+      request('GET', url).end().then(function(res) {
+        done(new Error('error should not should not succeed'));
+
+      }, function(err) {
+        assert.ok(err);
+      }).then(done).catch(done);
+    });
+  });
+
+  suite('#then', function() {
+    test('issue request', function(done) {
+      var addr = server.address();
+      var url = 'http://' + addr.address + ':' + addr.port + '/success';
+
+      request('GET', url).then(function(res) {
+        assert.equal(res.text, successBody);
+      }).then(done).catch(done);
+    });
+
+    test('issue request with .get', function(done) {
+      var addr = server.address();
+      var url = 'http://' + addr.address + ':' + addr.port + '/success';
+
+      request.get(url).then(function(res) {
+        assert.equal(res.text, successBody);
+      }).then(done).catch(done);
+    });
+
+    test('issue 404 request', function(done) {
+      var addr = server.address();
+      var url = 'http://' + addr.address + ':' + addr.port + '/NotFound';
+
+      request('GET', url).then(undefined, function(err) {
+        assert.equal(err.status, 404)
+        assert.equal(err.response.text, errorBody);
+
+      }).then(done).catch(done);
+    });
+
+    test('test error', function(done) {
+      var addr = server.address();
+      var url = 'http://' + addr.address + ':' + addr.port + '/error';
+
+      request('GET', url).then(function(res) {
+        done(new Error('error should not should not succeed'));
+
+      }, function(err) {
+        assert.ok(err);
+      }).then(done).catch(done);
+    });
+  })
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "superagent-promise",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "description": "superagent promise wrapper",
   "main": "index.js",
   "scripts": {
@@ -20,17 +20,14 @@
   "bugs": {
     "url": "https://github.com/lightsofapollo/superagent-promise/issues"
   },
-  "peerDependencies": {
-    "superagent": ">= 0.16.0",
-    "promise": ">= 3.2.0"
-  },
   "devDependencies": {
     "browser-test": "0.0.0-alpha.2",
-    "component": "^1.0.0-rc5",
-    "debug": "0.7.4",
-    "mocha": "^1.20.1",
-    "node-static": "^0.7.3",
-    "promise": ">= 3.2.0",
-    "superagent": ">= 0.16.0"
+    "chai": "^2.3.0",
+    "component": "^1.1.0",
+    "debug": "2.2.0",
+    "es6-promise": "^2.1.1",
+    "mocha": "^2.2.5",
+    "node-static": "^0.7.6",
+    "superagent": ">= 1.2.0"
   }
 }


### PR DESCRIPTION
* the peer dependencies on superagent and promise are being deprecated
since peer dependencies in npm@3 are changing.
* bump version to 1.0 since superagent is now >1.0 and since this will break code written against v0.2.0
* add tests against `then` on the wrapped superagent

By returning the `wrap` function directly we can avoid the bundled dependency on `promise` and allow users to specify their preferred promise library. (which will solve #5 and make #3 irrelevant)

While this will break existing installs, the code changes required to transition are minimal.  Where before clients would have
```
var agent = require('superagent-promise');
```
they will now have
```
var agent = require('superagent-promise')(require('superagent'), require('promise'));
```