### PR TITLE
updated fail to return response

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ function wrap(superagent, Promise) {
         }
 
         if (err) {
-          reject(err);
+          reject({error:err, response:response});
         } else {
           accept(response);
         }
@@ -42,7 +42,7 @@ function wrap(superagent, Promise) {
     return new Promise(function(accept, reject) {
       _end.call(self, function(err, response) {
         if (err) {
-          reject(err);
+          reject({error:err, response:response});
         } else {
           accept(response);
         }


### PR DESCRIPTION
Previously, the response from the server is hidden for any non 200 responses, which hides validation messages. This commit allows error handling as detailed in the original superagent. http://visionmedia.github.io/superagent/#error-handling