### PR TITLE
add response to err

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,6 +26,7 @@ function wrap(superagent, Promise) {
         }
 
         if (err) {
+          err.response = response;
           reject(err);
         } else {
           accept(response);
@@ -42,6 +43,7 @@ function wrap(superagent, Promise) {
     return new Promise(function(accept, reject) {
       _end.call(self, function(err, response) {
         if (err) {
+          err.response = response;
           reject(err);
         } else {
           accept(response);

--- a/index_test.js
+++ b/index_test.js
@@ -135,6 +135,7 @@ describe('superagent-promise', function() {
 
       }, function(err) {
         assert.ok(err);
+        assert.ok('response' in err);
         done();
       });
     });
@@ -175,6 +176,7 @@ describe('superagent-promise', function() {
 
       }, function(err) {
         assert.ok(err);
+        assert.ok('response' in err);
         done();
       });
     });


### PR DESCRIPTION
I used the awesome module with react, and it works but just a flaw when I try to use superagent-promise in await/async syntax.

See the below:

```js
async function test () {
  try {
    await promisedAgent.get('/foo').end();
  } catch (e) {
    // here I can't access the response
  }
}
```

Hence, I propose that exposing `response` at the `e`.

/cc @lightsofapollo 