### PR TITLE
Inherit static methods and properties from superagent

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,6 +60,15 @@ function wrap(superagent, Promise) {
     return new PromiseRequest(method, url);
   };
 
+  /**
+   * Inherit methods and properties from superagent so we can use request the same way as superagent
+   */
+  for (var method in superagent) {
+    if (superagent.hasOwnProperty(method)) {
+      request[method] = superagent[method];
+    }
+  }
+
   /** Helper for making an options request */
   request.options = function(url) {
     return request('OPTIONS', url);

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -1,8 +1,10 @@
 Object.keys(require.cache).forEach(function(key) { delete require.cache[key]; });
 
 var assert  = require('assert');
-var Promise = require('es6-promise').Promise
-var request = require('../index')(require('superagent'), Promise);
+var superagent = require('superagent');
+var Promise = require('es6-promise').Promise;
+var wrapRequest = require('../index');
+var request = wrapRequest(superagent, Promise);
 var http    = require('http');
 var debug   = require('debug')('test:index');
 
@@ -107,6 +109,18 @@ describe('superagent-promise', function() {
           assert(p instanceof Promise);
         });
       })
+    });
+  });
+
+  describe('inherited methods', function() {
+    it('should have an agent method', function() {
+      assert.equal(typeof request.agent, 'function')
+    });
+    it('should inherit new properties added to superagent', function() {
+      superagent.foo = 'bar';
+      var r = wrapRequest(superagent, Promise)
+      assert.equal(r.foo, 'bar')
+      delete superagent.foo
     });
   });
 


### PR DESCRIPTION
Fixes #12 - copies static members from superagent to request instance, which will include the `agent()` method.

Added test for agent and test verifying that adding a static property will work. (I have a use case elsewhere where I needed this functionality).