### PR TITLE
Add type definitions for TypeScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,40 @@ var mocks = require('./mock.config')('localhost', SUCCESS_BODY);
 require('superagent-mock')(mockedRequest, mocks);
 var request = require('../index')(mockedRequest, Promise);
 ```
+
+## Typescript
+
+This module provides a type definition file so it can be used from Typescript.
+You do **not** need to use `typings` to install, since it is included in the
+NPM package itself. However, it does depend on the `node` typings, and you
+will need the `superagent` typings in order to import superagent.
+
+```
+# install superagent and superagent-promise
+npm install superagent superagent-promise --save
+
+# install typings for node and superagent.
+typings install node --source=dt --global --save
+typings install superagent --source=dt --global --save
+```
+
+```typescript
+/// <reference path="./typings/index.d.ts" />
+
+import * as superagent from 'superagent';
+import * as superagentPromise from 'superagent-promise';
+
+const request = superagentPromise(superagent, Promise);
+
+request
+  .get('http://github.com')
+  .set('X-Awesome', 'superagent-promise')
+  .end()
+  .then(r => {
+    // r is of type SuperAgentResponse
+    console.log(`Status: ${r.status}`);
+  })
+  .catch(err => {
+    console.error(err);
+  });
+```

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,98 @@
+import stream = require('stream');
+
+declare namespace request {
+  interface SuperAgent {
+    (url: string): SuperAgentRequest;
+    (method: string, url: string): SuperAgentRequest;
+    agent(): SuperAgent;
+    get(url: string): SuperAgentRequest;
+    post(url: string): SuperAgentRequest;
+    put(url: string): SuperAgentRequest;
+    head(url: string): SuperAgentRequest;
+    del(url: string): SuperAgentRequest;
+    delete(url: string): SuperAgentRequest;
+    options(url: string): SuperAgentRequest;
+    trace(url: string): SuperAgentRequest;
+    copy(url: string): SuperAgentRequest;
+    lock(url: string): SuperAgentRequest;
+    mkcol(url: string): SuperAgentRequest;
+    move(url: string): SuperAgentRequest;
+    purge(url: string): SuperAgentRequest;
+    propfind(url: string): SuperAgentRequest;
+    proppatch(url: string): SuperAgentRequest;
+    unlock(url: string): SuperAgentRequest;
+    report(url: string): SuperAgentRequest;
+    mkactivity(url: string): SuperAgentRequest;
+    checkout(url: string): SuperAgentRequest;
+    merge(url: string): SuperAgentRequest;
+    notify(url: string): SuperAgentRequest;
+    subscribe(url: string): SuperAgentRequest;
+    unsubscribe(url: string): SuperAgentRequest;
+    patch(url: string): SuperAgentRequest;
+    search(url: string): SuperAgentRequest;
+    connect(url: string): SuperAgentRequest;
+
+    parse(fn: Function): SuperAgentRequest;
+    saveCookies(res: SuperAgentResponse): void;
+    attachCookies(req: SuperAgentRequest): void;
+  }
+
+  interface SuperAgentResponse {
+    text: string;
+    body: any;
+    files: any;
+    header: any;
+    type: string;
+    charset: string;
+    status: number;
+    statusType: number;
+    info: boolean;
+    ok: boolean;
+    redirect: boolean;
+    clientError: boolean;
+    serverError: boolean;
+    error: Error;
+    accepted: boolean;
+    noContent: boolean;
+    badRequest: boolean;
+    unauthorized: boolean;
+    notAcceptable: boolean;
+    notFound: boolean;
+    forbidden: boolean;
+    get(header: string): string;
+  }
+
+  interface SuperAgentRequest {
+    abort(): void;
+    accept(type: string): SuperAgentRequest;
+    attach(field: string, file: string, filename?: string): SuperAgentRequest;
+    auth(user: string, name: string): SuperAgentRequest;
+    buffer(val: boolean): SuperAgentRequest;
+    clearTimeout(): SuperAgentRequest;
+    field(name: string, val: string): SuperAgentRequest;
+    get(field: string): string;
+    on(name: string, handler: Function): SuperAgentRequest;
+    on(name: 'error', handler: (err: any) => void): SuperAgentRequest;
+    part(): SuperAgentRequest;
+    pipe(stream: NodeJS.WritableStream, options?: Object): stream.Writable;
+    query(val: Object): SuperAgentRequest;
+    redirects(n: number): SuperAgentRequest;
+    send(data: string): SuperAgentRequest;
+    send(data: Object): SuperAgentRequest;
+    send(): SuperAgentRequest;
+    set(field: string, val: string): SuperAgentRequest;
+    set(field: Object): SuperAgentRequest;
+    timeout(ms: number): SuperAgentRequest;
+    type(val: string): SuperAgentRequest;
+    use(fn: Function): SuperAgentRequest;
+    withCredentials(): SuperAgentRequest;
+    write(buffer: Buffer|string, cb?: Function): boolean;
+    write(str: string, encoding?: string, cb?: Function): boolean;
+
+    end(): Promise<SuperAgentResponse>
+  }
+}
+
+declare function request(superagent: any, promise: any): request.SuperAgent;
+
+export = request;

--- a/package.json
+++ b/package.json
@@ -28,5 +28,6 @@
     "mocha": "^2.2.5",
     "superagent": ">= 1.2.0",
     "superagent-mock": "^1.3.0"
-  }
+  },
+  "typings": "index.d.ts"
 }


### PR DESCRIPTION
My first crack at #25. If the @typings folks could help out by reviewing this, I'd really appreciate it!

This has been working for me. I made a minimal example here: https://github.com/apeace/sa-promise-test

However, you'll notice I [had to use a type assertion](https://github.com/apeace/sa-promise-test/blob/master/index.ts#L5) to get WebStorm to recognize the type correctly. Without the type assertion, it sees the type of `request` as `any`. I'm not sure if this is a WebStorm problem or something I've done incorrectly in the type definitions.

Big thanks to anyone who would like to help with this :)
